### PR TITLE
Find unused palette entries in generated themes, and fix the FIXME

### DIFF
--- a/autothemer.el
+++ b/autothemer.el
@@ -65,6 +65,7 @@ bindings within both the REDUCED-SPECS and the BODY."
          (temp-colorname (make-symbol "colorname")))
     (setq face-customizer
           `(let ((,face-specs)
+                 (,temp-color-structs)
                  (,temp-defined-colors))
              (deftheme ,name ,description)
              ,@(cl-loop for n from 0 to (1- n-displays)

--- a/autothemer.el
+++ b/autothemer.el
@@ -73,22 +73,21 @@ bindings within both the REDUCED-SPECS and the BODY."
                         `(let* ,(autothemer--extract-let-block full-palette n)
                            ,@(when (and body (eq n 0))
                                body)
-                           ;; FIXME: instead of emitting this code for all n,
-                           ;; and including a runtime check for n = 0, the when
-                           ;; clause below should only be emitted for n = 0 in
-                           ;; the first place
-                           (when ,(eq n 0)
-                             (setq ,temp-defined-colors
-                                   (list ,@(--map (list 'list `',it it) color-names)))
-                             (setq ,temp-color-structs
-                                   (cl-loop for (,temp-colorname ,temp-color)
-                                            in ,temp-defined-colors
-                                            collect (make-autothemer--color :name ,temp-colorname
-                                                                            :value ,temp-color)))
-                             (setq autothemer--current-theme
-                                   (make-autothemer--theme
-                                    :colors ,temp-color-structs
-                                    :defined-faces ',face-names)))
+                           ,(when (> n 0)
+                              `(ignore ,@color-names))
+                           ,(when (and (eq n 0) (not (bound-and-true-p byte-compile-current-file)))
+                              `(progn
+                                 (setq ,temp-defined-colors
+                                       (list ,@(--map (list 'list `',it it) color-names)))
+                                 (setq ,temp-color-structs
+                                       (cl-loop for (,temp-colorname ,temp-color)
+                                                in ,temp-defined-colors
+                                                collect (make-autothemer--color :name ,temp-colorname
+                                                                                :value ,temp-color)))
+                                 (setq autothemer--current-theme
+                                       (make-autothemer--theme
+                                        :colors ,temp-color-structs
+                                        :defined-faces ',face-names))))
                            (setq ,face-specs
                                  (autothemer--append-column
                                   ,face-specs


### PR DESCRIPTION
Find unused palette entries in generated themes
    
Emit `autothemer--current-theme` code only once when n=0 and not byte-compiled.
On a theme using lexical scope this raises byte compiler warnings when `palette` entries are defined, but not used in either `reserved-specs` or `body`.
This breaks `autothemer-generate-templates` when loading a byte-compiled theme, however the default with `load-theme` is to load the `.el` file even if `.elc` is present, so this won't affect the majority of users.
    
Because we emit `body` only when `n=0` emit an `ignore` when `n>0` to avoid spurious warnings.
    
This commit is best reviewed by ignoring whitespace changes.