### PR TITLE
Do not require autothemer or dash at runtime.

### DIFF
--- a/autothemer.el
+++ b/autothemer.el
@@ -226,10 +226,10 @@ palette used in the most recent invocation of
     (with-current-buffer buffer (emacs-lisp-mode) (insert (pp templates)))
     (switch-to-buffer buffer)))
 
-(defun autothemer--append-column (list-of-lists new-column)
+(cl-defsubst autothemer--append-column (list-of-lists new-column)
   "If LIST-OF-LISTS is nil, return NEW-COLUMN.  Otherwise, append to every element of LIST-OF-LISTS the corresponding element of NEW-COLUMN."
   (cl-assert (or (not list-of-lists) (eq (length list-of-lists) (length new-column))))
-  (if list-of-lists (-zip-with #'append list-of-lists new-column)
+  (if list-of-lists (inline (-zip-with #'append list-of-lists new-column))
     new-column))
 
 (provide 'autothemer)


### PR DESCRIPTION
Fully expand  autothemer--append-column, and -zip-with at compile time.

This allows putting a theme's .elc file into `custom-theme-load-path`
and having it load without loading autothemer or dash first.
(Unfortunately `load-theme` always loads the .el if it exists, so this
 won't help when installing the whole package)