### PR TITLE
Fix byte-compile docstring warnings; test on Emacs 30.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Autothemer Tests
 
 on:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
 
@@ -19,12 +19,13 @@ jobs:
           - 27.2
           - 28.1
           - 28.2
+          - 30.1
           - snapshot
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Set up Emacs
-      uses: purcell/setup-emacs@v4.0
+      uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}
 

--- a/autothemer.el
+++ b/autothemer.el
@@ -157,8 +157,8 @@ This is the default `autothemer-brightness-group'.")
 For example:
 
      (autothemer--reduced-spec-to-facespec
-        '(min-colors 60)
-        '(button (:underline t :foreground red)))
+        \='(min-colors 60)
+        \='(button (:underline t :foreground red)))
      ;; => `(button (((min-colors 60) (:underline ,t :foreground ,red))))."
   (let* ((face (elt reduced-specs 0))
          (properties (elt reduced-specs 1))
@@ -532,8 +532,8 @@ See also `autothemer--color-p',
 
 For example:
 
-    (autothemer--plist-bind (a b c) '(:a 1 :b 2 :c 3) (list a b))
-    => '(1 2)
+    (autothemer--plist-bind (a b c) \='(:a 1 :b 2 :c 3) (list a b))
+    => \='(1 2)
 
 If PLIST is nil, ARGS are bound to BODY nil values."
   `(if (listp ,plist)


### PR DESCRIPTION
## Summary

Two small, behaviour-preserving improvements found while byte-compiling
`autothemer.el` with a recent Emacs.

### Fix: unescaped single quotes in two docstrings

The byte-compiler emits:

```
autothemer.el:154:2: Warning: docstring has wrong usage of unescaped
  single quotes (use \=' or different quoting such as `...')
autothemer.el:530:2: Warning: docstring has wrong usage of unescaped
  single quotes (use \=' or different quoting such as `...')
```

The docstrings of `autothemer--reduced-spec-to-facespec` and
`autothemer--plist-bind` contain quoted-list examples like
`'(min-colors 60)`. The checker pairs the leading `'` with a later
quote as a text-quote span. Escaping the opening quote with `\='` (the
fix the warning itself suggests) silences the warning. Only the
docstring text changes; the rendered examples are identical and no code
behaviour changes. This is compatible with the declared minimum
(Emacs 26.1).

### CI: test on Emacs 30.1 and add Dependabot

- Add Emacs `30.1` to the existing test matrix so the suite also runs
  against the latest stable release.
- Bump `actions/checkout` to v5 and pin `purcell/setup-emacs` to master.
- Add a weekly Dependabot config for GitHub Actions.

### Verification

- Byte-compile confirms both docstring warnings are gone and no new
  warnings are introduced.
- `check-parens` passes.
- The full ERT suite passes (26/26) locally and on the fork CI across
  Emacs 26.1-28.2, 30.1, and snapshot (all jobs green).

Note: `autothemer.el` still emits other byte-compile warnings (unused
lexical arguments in the `cl-defun` palette functions, and an
`lm-homepage` obsolete notice that only appears on Emacs 31+). Those are
left untouched here because fixing them safely needs design decisions
beyond a docstring cleanup.